### PR TITLE
Feature/add switch markup extension

### DIFF
--- a/src/SmartMvvm.Xaml.Sample/MainWindow.xaml
+++ b/src/SmartMvvm.Xaml.Sample/MainWindow.xaml
@@ -26,5 +26,8 @@
         <TabItem Header="Type">
             <sample:EqualTypeView />
         </TabItem>
+        <TabItem Header="Switch">
+            <sample:SwitchView />
+        </TabItem>
     </TabControl>
 </Window>

--- a/src/SmartMvvm.Xaml.Sample/SwitchView.xaml
+++ b/src/SmartMvvm.Xaml.Sample/SwitchView.xaml
@@ -1,0 +1,80 @@
+﻿<UserControl x:Class="SmartMvvm.Xaml.Sample.SwitchView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             x:Name="View"
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             mc:Ignorable="d">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="400" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <ListBox x:Name="ListBox"
+                 Grid.ColumnSpan="{If {Greater {Binding ElementName=View, Path=ActualWidth},
+                                               {Double 600}},
+                                      Then={Int 1},
+                                      Else={Int 2}}">
+            <ListBoxItem Content="Blue" />
+            <ListBoxItem Content="Green" />
+            <ListBoxItem Content="Red" />
+            <ListBoxItem Content="Orange" />
+            <ListBoxItem Content="Yellow" />
+            <ListBoxItem Content="Custom" />
+        </ListBox>
+        <StackPanel
+            Grid.Row="{If {Greater {Binding ElementName=View, Path=ActualWidth},
+                                           {Double 600}},
+                                  Then={Int 0},
+                                  Else={Int 1}}"
+            Grid.Column="{If {Greater {Binding ElementName=View, Path=ActualWidth},
+                                              {Double 600}},
+                                     Then={Int 2},
+                                     Else={Int 0}}"
+            Grid.ColumnSpan="{If {Greater {Binding ElementName=View, Path=ActualWidth},
+                                                  {Double 600}},
+                                         Then={Int 1},
+                                         Else={Int 2}}"
+            Margin="5">
+            <TextBlock Margin="0,0,0,5"
+                       Text="Custom color:" />
+            <ComboBox x:Name="CustomColorPicker"
+                      SelectedIndex="0">
+                <ComboBox.Items>
+                    <SolidColorBrush Color="RosyBrown" />
+                    <SolidColorBrush Color="LightBlue" />
+                    <SolidColorBrush Color="Fuchsia" />
+                </ComboBox.Items>
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal">
+                            <Rectangle Fill="{Binding }"
+                                       Width="16"
+                                       Height="16"
+                                       Margin="2" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+            <TextBlock Margin="0,0,0,5"
+                       Text="Selected color:" />
+            <Border BorderBrush="Black"
+                    BorderThickness="0.5"
+                    Height="20"
+                    Width="20"
+                    HorizontalAlignment="Left">
+                <Rectangle
+                    Fill="{Switch {Binding ElementName=ListBox, Path=SelectedIndex},
+                                {Case {Int 0}, {x:Static Brushes.Blue}},
+                                {Case {Int 1}, {x:Static Brushes.Green}},
+                                {Case {Int 2}, {x:Static Brushes.Red}},
+                                {Case {Int 3}, {x:Static Brushes.Orange}},
+                                {Case {Int 4}, {x:Static Brushes.Yellow}},
+                                {Case {Int 5}, {Binding ElementName=CustomColorPicker, Path=SelectedItem.Content}},
+                                Default={x:Static Brushes.Transparent}}" />
+            </Border>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/src/SmartMvvm.Xaml.Sample/SwitchView.xaml
+++ b/src/SmartMvvm.Xaml.Sample/SwitchView.xaml
@@ -22,7 +22,6 @@
             <ListBoxItem Content="Red" />
             <ListBoxItem Content="Orange" />
             <ListBoxItem Content="Yellow" />
-            <ListBoxItem Content="Custom" />
         </ListBox>
         <StackPanel
             Grid.Row="{If {Greater {Binding ElementName=View, Path=ActualWidth},
@@ -39,26 +38,6 @@
                                          Else={Int 2}}"
             Margin="5">
             <TextBlock Margin="0,0,0,5"
-                       Text="Custom color:" />
-            <ComboBox x:Name="CustomColorPicker"
-                      SelectedIndex="0">
-                <ComboBox.Items>
-                    <SolidColorBrush Color="RosyBrown" />
-                    <SolidColorBrush Color="LightBlue" />
-                    <SolidColorBrush Color="Fuchsia" />
-                </ComboBox.Items>
-                <ComboBox.ItemTemplate>
-                    <DataTemplate>
-                        <StackPanel Orientation="Horizontal">
-                            <Rectangle Fill="{Binding }"
-                                       Width="16"
-                                       Height="16"
-                                       Margin="2" />
-                        </StackPanel>
-                    </DataTemplate>
-                </ComboBox.ItemTemplate>
-            </ComboBox>
-            <TextBlock Margin="0,0,0,5"
                        Text="Selected color:" />
             <Border BorderBrush="Black"
                     BorderThickness="0.5"
@@ -72,7 +51,6 @@
                                 {Case {Int 2}, {x:Static Brushes.Red}},
                                 {Case {Int 3}, {x:Static Brushes.Orange}},
                                 {Case {Int 4}, {x:Static Brushes.Yellow}},
-                                {Case {Int 5}, {Binding ElementName=CustomColorPicker, Path=SelectedItem.Content}},
                                 Default={x:Static Brushes.Transparent}}" />
             </Border>
         </StackPanel>

--- a/src/SmartMvvm.Xaml.Sample/SwitchView.xaml.cs
+++ b/src/SmartMvvm.Xaml.Sample/SwitchView.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace SmartMvvm.Xaml.Sample
+{
+    public partial class SwitchView
+    {
+        public SwitchView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/SmartMvvm.Xaml.UnitTests/Markup/SwitchTest.cs
+++ b/src/SmartMvvm.Xaml.UnitTests/Markup/SwitchTest.cs
@@ -1,0 +1,32 @@
+using System.Windows.Data;
+using SmartMvvm.Xaml.Markup;
+using SmartMvvm.Xaml.UnitTests.Markup.Logic;
+using Xunit;
+
+namespace SmartMvvm.Xaml.UnitTests.Markup
+{
+    public class SwitchTest
+    {
+        [Theory]
+        [InlineData(20, 4)] // first case
+        [InlineData(30, 5)] // second case
+        [InlineData(null, 7)] // null case
+        [InlineData(-1, 10)] // default
+        public void Resolve_Value(object input, object expected)
+        {
+            var firstCase = new Case(20, 4);
+            var secondCase = new Case(30, 5);
+            var nullCase = new Case(null, 7);
+            const int defaultValue = 10;
+
+            // given
+            var sut = new Switch(new Binding { Source = input }, firstCase, secondCase, nullCase) { Default = defaultValue };
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/src/SmartMvvm.Xaml.UnitTests/Markup/SwitchTest.cs
+++ b/src/SmartMvvm.Xaml.UnitTests/Markup/SwitchTest.cs
@@ -1,3 +1,4 @@
+using System.Windows;
 using System.Windows.Data;
 using SmartMvvm.Xaml.Markup;
 using SmartMvvm.Xaml.UnitTests.Markup.Logic;
@@ -7,20 +8,204 @@ namespace SmartMvvm.Xaml.UnitTests.Markup
 {
     public class SwitchTest
     {
-        [Theory]
-        [InlineData(20, 4)] // first case
-        [InlineData(30, 5)] // second case
-        [InlineData(null, 7)] // null case
-        [InlineData(-1, 10)] // default
-        public void Resolve_Value(object input, object expected)
-        {
-            var firstCase = new Case(20, 4);
-            var secondCase = new Case(30, 5);
-            var nullCase = new Case(null, 7);
-            const int defaultValue = 10;
+        private const int DefaultValue = 0;
+        private readonly Case _firstCase = new Case(1, 10);
+        private readonly Case _secondCase = new Case(2, 20);
+        private readonly Case _thirdCase = new Case(3, 30);
+        private readonly Case _fourthCase = new Case(4, 40);
+        private readonly Case _fifthCase = new Case(5, 50);
+        private readonly Case _sixthCase = new Case(6, 60);
+        private readonly Case _seventhCase = new Case(7, 70);
+        private readonly Case _eightCase = new Case(8, 80);
+        private readonly Case _nullCase = new Case(null, -10);
 
+        [Fact]
+        public void Resolve_Value_OneCase_WithBinding()
+        {
             // given
-            var sut = new Switch(new Binding { Source = input }, firstCase, secondCase, nullCase) { Default = defaultValue };
+            var sut = new Switch(new Binding { Source = new Binding {Source = 1} }, new Case(new Binding {Source = 1}, 10));
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(10, result);
+        }
+        
+        [Fact]
+        public void Resolve_Value_NoDefaultDefined()
+        {
+            // given
+            var sut = new Switch(new Binding { Source = 100 });
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(DependencyProperty.UnsetValue, result);
+        }
+        
+        [Fact]
+        public void Resolve_Value_NoNullDefined()
+        {
+            // given
+            var sut = new Switch(new Binding { Source = null });
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(DependencyProperty.UnsetValue, result);
+        }
+        
+        [Theory]
+        [InlineData(1, 10)] // first case
+        [InlineData(null, -10)] // null case
+        [InlineData(10, 0)] // default
+        public void Resolve_Value_OneCase(object input, object expected)
+        {
+            // given
+            var sut = new Switch(new Binding { Source = input }, _firstCase, _nullCase) { Default = DefaultValue };
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(expected, result);
+        }
+        
+        [Theory]
+        [InlineData(1, 10)] // first case
+        [InlineData(2, 20)] // second case
+        [InlineData(null, -10)] // null case
+        [InlineData(10, 0)] // default
+        public void Resolve_Value_TwoCases(object input, object expected)
+        {
+            // given
+            var sut = new Switch(new Binding { Source = input }, _firstCase, _secondCase, _nullCase) { Default = DefaultValue };
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(expected, result);
+        }
+        
+        [Theory]
+        [InlineData(1, 10)] // first case
+        [InlineData(2, 20)] // second case
+        [InlineData(3, 30)] // third case
+        [InlineData(null, -10)] // null case
+        [InlineData(10, 0)] // default
+        public void Resolve_Value_ThreeCases(object input, object expected)
+        {
+            // given
+            var sut = new Switch(new Binding { Source = input }, _firstCase, _secondCase, _thirdCase, _nullCase) { Default = DefaultValue };
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(expected, result);
+        }
+        
+        [Theory]
+        [InlineData(1, 10)] // first case
+        [InlineData(2, 20)] // second case
+        [InlineData(3, 30)] // third case
+        [InlineData(4, 40)] // fourth case
+        [InlineData(null, -10)] // null case
+        [InlineData(10, 0)] // default
+        public void Resolve_Value_FourthCases(object input, object expected)
+        {
+            // given
+            var sut = new Switch(new Binding { Source = input }, _firstCase, _secondCase, _thirdCase, _fourthCase, _nullCase) { Default = DefaultValue };
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(expected, result);
+        }
+        
+        [Theory]
+        [InlineData(1, 10)] // first case
+        [InlineData(2, 20)] // second case
+        [InlineData(3, 30)] // third case
+        [InlineData(4, 40)] // fourth case
+        [InlineData(5, 50)] // fifth case
+        [InlineData(null, -10)] // null case
+        [InlineData(10, 0)] // default
+        public void Resolve_Value_FifthCases(object input, object expected)
+        {
+            // given
+            var sut = new Switch(new Binding { Source = input }, _firstCase, _secondCase, _thirdCase, _fourthCase, _fifthCase, _nullCase) { Default = DefaultValue };
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(expected, result);
+        }
+        
+        [Theory]
+        [InlineData(1, 10)] // first case
+        [InlineData(2, 20)] // second case
+        [InlineData(3, 30)] // third case
+        [InlineData(4, 40)] // fourth case
+        [InlineData(5, 50)] // fifth case
+        [InlineData(6, 60)] // sixth case
+        [InlineData(null, -10)] // null case
+        [InlineData(10, 0)] // default
+        public void Resolve_Value_SixthCases(object input, object expected)
+        {
+            // given
+            var sut = new Switch(new Binding { Source = input }, _firstCase, _secondCase, _thirdCase, _fourthCase, _fifthCase, _sixthCase, _nullCase) { Default = DefaultValue };
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(expected, result);
+        }
+        
+        [Theory]
+        [InlineData(1, 10)] // first case
+        [InlineData(2, 20)] // second case
+        [InlineData(3, 30)] // third case
+        [InlineData(4, 40)] // fourth case
+        [InlineData(5, 50)] // fifth case
+        [InlineData(6, 60)] // sixth case
+        [InlineData(7, 70)] // seventh case
+        [InlineData(null, -10)] // null case
+        [InlineData(10, 0)] // default
+        public void Resolve_Value_SeventhCases(object input, object expected)
+        {
+            // given
+            var sut = new Switch(new Binding { Source = input }, _firstCase, _secondCase, _thirdCase, _fourthCase, _fifthCase, _sixthCase, _seventhCase, _nullCase) { Default = DefaultValue };
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(expected, result);
+        }
+        
+        [Theory]
+        [InlineData(1, 10)] // first case
+        [InlineData(2, 20)] // second case
+        [InlineData(3, 30)] // third case
+        [InlineData(4, 40)] // fourth case
+        [InlineData(5, 50)] // fifth case
+        [InlineData(6, 60)] // sixth case
+        [InlineData(7, 70)] // seventh case
+        [InlineData(8, 80)] // eight case
+        [InlineData(null, -10)] // null case
+        [InlineData(10, 0)] // default
+        public void Resolve_Value_EigthCases(object input, object expected)
+        {
+            // given
+            var sut = new Switch(new Binding { Source = input }, _firstCase, _secondCase, _thirdCase, _fourthCase, _fifthCase, _sixthCase, _seventhCase, _eightCase, _nullCase) { Default = DefaultValue };
 
             // when
             var result = Evaluator.Evaluate(sut);

--- a/src/SmartMvvm.Xaml.UnitTests/Markup/SwitchTest.cs
+++ b/src/SmartMvvm.Xaml.UnitTests/Markup/SwitchTest.cs
@@ -1,4 +1,3 @@
-using System.Windows;
 using System.Windows.Data;
 using SmartMvvm.Xaml.Markup;
 using SmartMvvm.Xaml.UnitTests.Markup.Logic;
@@ -20,19 +19,6 @@ namespace SmartMvvm.Xaml.UnitTests.Markup
         private readonly Case _nullCase = new Case(null, -10);
 
         [Fact]
-        public void Resolve_Value_OneCase_WithBinding()
-        {
-            // given
-            var sut = new Switch(new Binding { Source = new Binding {Source = 1} }, new Case(new Binding {Source = 1}, 10));
-
-            // when
-            var result = Evaluator.Evaluate(sut);
-
-            // then
-            Assert.Equal(10, result);
-        }
-        
-        [Fact]
         public void Resolve_Value_NoDefaultDefined()
         {
             // given
@@ -42,7 +28,7 @@ namespace SmartMvvm.Xaml.UnitTests.Markup
             var result = Evaluator.Evaluate(sut);
 
             // then
-            Assert.Equal(DependencyProperty.UnsetValue, result);
+            Assert.Null(result);
         }
         
         [Fact]
@@ -55,7 +41,7 @@ namespace SmartMvvm.Xaml.UnitTests.Markup
             var result = Evaluator.Evaluate(sut);
 
             // then
-            Assert.Equal(DependencyProperty.UnsetValue, result);
+            Assert.Null(result);
         }
         
         [Theory]

--- a/src/SmartMvvm.Xaml/Markup/Case.cs
+++ b/src/SmartMvvm.Xaml/Markup/Case.cs
@@ -3,25 +3,41 @@ using System.Windows.Markup;
 
 namespace SmartMvvm.Xaml.Markup
 {
+    /// <summary>
+    /// Represents a markup extension for defining a <see cref="Case"/> inside a <see cref="Switch"/>.
+    /// </summary>
     public class Case : MarkupExtension
     {
         #region methods
 
+        /// <inheritdoc />
         public override object ProvideValue(IServiceProvider serviceProvider) => this;
 
         #endregion
 
         #region constructors
-
+        
+        /// <summary>
+        /// Initializes a new instance of <see cref="Case"/>.
+        /// </summary>
         public Case()
         {
         }
-
+        
+        /// <summary>
+        /// Initializes a new instance of <see cref="Case"/>.
+        /// </summary>
+        /// <param name="key">The key of the <see cref="Case"/></param>
         public Case(object key)
         {
             Key = key;
         }
 
+        /// <summary>
+        /// Initializes a new instance of <see cref="Case"/>.
+        /// </summary>
+        /// <param name="key">The key of the <see cref="Case"/></param>
+        /// <param name="value">The value of the <see cref="Case"/></param>
         public Case(object key, object value) : this(key)
         {
             Value = value;
@@ -31,8 +47,14 @@ namespace SmartMvvm.Xaml.Markup
 
         #region properties
 
+        /// <summary>
+        /// Gets or sets the key.
+        /// </summary>
         public object Key { get; set; }
 
+        /// <summary>
+        /// Gets or sets the value.
+        /// </summary>
         public object Value { get; set; }
 
         #endregion

--- a/src/SmartMvvm.Xaml/Markup/Case.cs
+++ b/src/SmartMvvm.Xaml/Markup/Case.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Windows.Markup;
+
+namespace SmartMvvm.Xaml.Markup
+{
+    public class Case : MarkupExtension
+    {
+        #region methods
+
+        public override object ProvideValue(IServiceProvider serviceProvider) => this;
+
+        #endregion
+
+        #region constructors
+
+        public Case()
+        {
+        }
+
+        public Case(object key)
+        {
+            Key = key;
+        }
+
+        public Case(object key, object value) : this(key)
+        {
+            Value = value;
+        }
+
+        #endregion
+
+        #region properties
+
+        public object Key { get; set; }
+
+        public object Value { get; set; }
+
+        #endregion
+    }
+}

--- a/src/SmartMvvm.Xaml/Markup/Switch.cs
+++ b/src/SmartMvvm.Xaml/Markup/Switch.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Collections;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Markup;
+
+namespace SmartMvvm.Xaml.Markup
+{
+    [ContentProperty(nameof(Cases))]
+    public class Switch : MarkupExtension
+    {
+        #region class CaseConverter
+
+        private class CaseConverter : IValueConverter
+        {
+            #region members
+
+            private readonly Switch _switch;
+
+            #endregion
+
+            #region constructors
+
+            public CaseConverter(Switch switchExtension)
+            {
+                _switch = switchExtension;
+            }
+
+            #endregion
+
+            #region methods
+
+            private object FindValue(object key)
+            {
+                if (key == null)
+                {
+                    return _switch._nullValue;
+                }
+
+                return _switch.Cases.Contains(key) ? _switch.Cases[key] : _switch.Default;
+            }
+
+            #endregion
+
+            #region interface IValueConverter
+
+            public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+            {
+                return FindValue(value);
+            }
+
+            public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            {
+                return DependencyProperty.UnsetValue;
+            }
+
+            #endregion
+        }
+
+        #endregion
+
+        #region members
+
+        private object _nullValue = DependencyProperty.UnsetValue;
+
+        #endregion
+
+        #region constructors
+
+        public Switch()
+        {
+        }
+
+        private Switch(Binding binding, params Case[] cases)
+        {
+            Binding = binding;
+
+            foreach (var @case in cases)
+            {
+                AddCase(@case);
+            }
+        }
+
+        public Switch(Binding binding) : this(binding, new Case[0])
+        {
+        }
+
+        public Switch(Binding binding, Case first) : this(binding, new[] { first })
+        {
+        }
+
+        public Switch(Binding binding, Case first, Case second) : this(binding, new[] { first, second })
+        {
+        }
+
+        public Switch(Binding binding, Case first, Case second, Case third) : this(binding,
+            new[] { first, second, third })
+        {
+        }
+
+        public Switch(Binding binding, Case first, Case second, Case third, Case fourth) : this(binding,
+            new[] { first, second, third, fourth })
+        {
+        }
+
+        public Switch(Binding binding, Case first, Case second, Case third, Case fourth, Case fifth) : this(binding,
+            new[] { first, second, third, fourth, fifth })
+        {
+        }
+
+        public Switch(Binding binding, Case first, Case second, Case third, Case fourth, Case fifth, Case sixth) : this(
+            binding, new[] { first, second, third, fourth, fifth, sixth })
+        {
+        }
+
+        public Switch(Binding binding, Case first, Case second, Case third, Case fourth, Case fifth, Case sixth,
+            Case seventh) : this(binding, new[] { first, second, third, fourth, fifth, sixth, seventh })
+        {
+        }
+
+        public Switch(Binding binding, Case first, Case second, Case third, Case fourth, Case fifth, Case sixth,
+            Case seventh, Case eight) : this(binding,
+            new[] { first, second, third, fourth, fifth, sixth, seventh, eight })
+        {
+        }
+
+        #endregion
+
+        #region properties
+
+        public Binding Binding { get; set; }
+
+        public ResourceDictionary Cases { get; set; } = new();
+
+        public object Default { get; set; } = DependencyProperty.UnsetValue;
+
+        #endregion
+
+        #region methods
+
+        private void AddCase(Case newCase)
+        {
+            if (newCase.Key == null)
+            {
+                _nullValue = newCase.Value;
+            }
+            else
+            {
+                Cases.Add(newCase.Key, newCase.Value);
+            }
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            Binding ??= new Binding();
+
+            if (Binding.Converter is not CaseConverter)
+            {
+                Binding.Converter = new CaseConverter(this);
+
+                ProcessCases(serviceProvider);
+            }
+
+            return Binding.ProvideValue(serviceProvider);
+        }
+
+        private void ProcessCases(IServiceProvider serviceProvider)
+        {
+            foreach (DictionaryEntry dictionaryEntry in Cases)
+            {
+                if (dictionaryEntry.Value is MarkupExtension bindingBase)
+                {
+                    Cases[dictionaryEntry.Key] = bindingBase.ProvideValue(serviceProvider);
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/SmartMvvm.Xaml/Markup/Switch.cs
+++ b/src/SmartMvvm.Xaml/Markup/Switch.cs
@@ -7,6 +7,9 @@ using System.Windows.Markup;
 
 namespace SmartMvvm.Xaml.Markup
 {
+    /// <summary>
+    /// Represents a markup extension for creating a switch expression.
+    /// </summary>
     [ContentProperty(nameof(Cases))]
     public class Switch : MarkupExtension
     {
@@ -67,7 +70,10 @@ namespace SmartMvvm.Xaml.Markup
         #endregion
 
         #region constructors
-
+        
+        /// <summary>
+        /// Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
         public Switch()
         {
         }
@@ -82,46 +88,137 @@ namespace SmartMvvm.Xaml.Markup
             }
         }
 
+        /// <summary>
+        ///  Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding"/></param>
         public Switch(Binding binding) : this(binding, new Case[0])
         {
         }
 
+        /// <summary>
+        ///  Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding"/></param>
+        /// <param name="first">The first <see cref="Case"/></param>
         public Switch(Binding binding, Case first) : this(binding, new[] { first })
         {
         }
 
+        /// <summary>
+        ///  Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding"/></param>
+        /// <param name="first">The first <see cref="Case"/></param>
+        /// <param name="second">The second <see cref="Case"/></param>
         public Switch(Binding binding, Case first, Case second) : this(binding, new[] { first, second })
         {
         }
 
+        /// <summary>
+        ///  Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding"/></param>
+        /// <param name="first">The first <see cref="Case"/></param>
+        /// <param name="second">The second <see cref="Case"/></param>
+        /// <param name="third">The third <see cref="Case"/></param>
         public Switch(Binding binding, Case first, Case second, Case third) : this(binding,
             new[] { first, second, third })
         {
         }
 
+        /// <summary>
+        ///  Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding"/></param>
+        /// <param name="first">The first <see cref="Case"/></param>
+        /// <param name="second">The second <see cref="Case"/></param>
+        /// <param name="third">The third <see cref="Case"/></param>
+        /// <param name="fourth">The fourth <see cref="Case"/></param>
         public Switch(Binding binding, Case first, Case second, Case third, Case fourth) : this(binding,
             new[] { first, second, third, fourth })
         {
         }
 
+        /// <summary>
+        ///  Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding"/></param>
+        /// <param name="first">The first <see cref="Case"/></param>
+        /// <param name="second">The second <see cref="Case"/></param>
+        /// <param name="third">The third <see cref="Case"/></param>
+        /// <param name="fourth">The fourth <see cref="Case"/></param>
+        /// <param name="fifth">The fifth <see cref="Case"/></param>
         public Switch(Binding binding, Case first, Case second, Case third, Case fourth, Case fifth) : this(binding,
             new[] { first, second, third, fourth, fifth })
         {
         }
 
+        /// <summary>
+        ///  Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding"/></param>
+        /// <param name="first">The first <see cref="Case"/></param>
+        /// <param name="second">The second <see cref="Case"/></param>
+        /// <param name="third">The third <see cref="Case"/></param>
+        /// <param name="fourth">The fourth <see cref="Case"/></param>
+        /// <param name="fifth">The fifth <see cref="Case"/></param>
+        /// <param name="sixth">The sixth <see cref="Case"/></param>
         public Switch(Binding binding, Case first, Case second, Case third, Case fourth, Case fifth, Case sixth) : this(
             binding, new[] { first, second, third, fourth, fifth, sixth })
         {
         }
 
+        /// <summary>
+        ///  Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding"/></param>
+        /// <param name="first">The first <see cref="Case"/></param>
+        /// <param name="second">The second <see cref="Case"/></param>
+        /// <param name="third">The third <see cref="Case"/></param>
+        /// <param name="fourth">The fourth <see cref="Case"/></param>
+        /// <param name="fifth">The fifth <see cref="Case"/></param>
+        /// <param name="sixth">The sixth <see cref="Case"/></param>
+        /// <param name="seventh">The seventh <see cref="Case"/></param>
         public Switch(Binding binding, Case first, Case second, Case third, Case fourth, Case fifth, Case sixth,
             Case seventh) : this(binding, new[] { first, second, third, fourth, fifth, sixth, seventh })
         {
         }
 
+        /// <summary>
+        ///  Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding"/></param>
+        /// <param name="first">The first <see cref="Case"/></param>
+        /// <param name="second">The second <see cref="Case"/></param>
+        /// <param name="third">The third <see cref="Case"/></param>
+        /// <param name="fourth">The fourth <see cref="Case"/></param>
+        /// <param name="fifth">The fifth <see cref="Case"/></param>
+        /// <param name="sixth">The sixth <see cref="Case"/></param>
+        /// <param name="seventh">The seventh <see cref="Case"/></param>
+        /// <param name="eight">The eight <see cref="Case"/></param>
         public Switch(Binding binding, Case first, Case second, Case third, Case fourth, Case fifth, Case sixth,
             Case seventh, Case eight) : this(binding,
             new[] { first, second, third, fourth, fifth, sixth, seventh, eight })
+        {
+        }
+        
+        /// <summary>
+        ///  Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding"/></param>
+        /// <param name="first">The first <see cref="Case"/></param>
+        /// <param name="second">The second <see cref="Case"/></param>
+        /// <param name="third">The third <see cref="Case"/></param>
+        /// <param name="fourth">The fourth <see cref="Case"/></param>
+        /// <param name="fifth">The fifth <see cref="Case"/></param>
+        /// <param name="sixth">The sixth <see cref="Case"/></param>
+        /// <param name="seventh">The seventh <see cref="Case"/></param>
+        /// <param name="eight">The eight <see cref="Case"/></param>
+        /// <param name="ninth">The ninth <see cref="Case"/></param>
+        public Switch(Binding binding, Case first, Case second, Case third, Case fourth, Case fifth, Case sixth,
+            Case seventh, Case eight, Case ninth) : this(binding,
+            new[] { first, second, third, fourth, fifth, sixth, seventh, eight, ninth })
         {
         }
 
@@ -129,10 +226,19 @@ namespace SmartMvvm.Xaml.Markup
 
         #region properties
 
+        /// <summary>
+        /// Gets or sets the <see cref="Binding"/>.
+        /// </summary>
         public Binding Binding { get; set; }
 
+        /// <summary>
+        /// Gets or sets the <see cref="Case"/>s.
+        /// </summary>
         public ResourceDictionary Cases { get; set; } = new();
 
+        /// <summary>
+        /// Gets or sets the default value.
+        /// </summary>
         public object Default { get; set; } = DependencyProperty.UnsetValue;
 
         #endregion
@@ -151,6 +257,7 @@ namespace SmartMvvm.Xaml.Markup
             }
         }
 
+        /// <inheritdoc />
         public override object ProvideValue(IServiceProvider serviceProvider)
         {
             Binding ??= new Binding();
@@ -169,9 +276,9 @@ namespace SmartMvvm.Xaml.Markup
         {
             foreach (DictionaryEntry dictionaryEntry in Cases)
             {
-                if (dictionaryEntry.Value is MarkupExtension bindingBase)
+                if (dictionaryEntry.Key is MarkupExtension markupExtension)
                 {
-                    Cases[dictionaryEntry.Key] = bindingBase.ProvideValue(serviceProvider);
+                    Cases[dictionaryEntry.Key] = markupExtension.ProvideValue(serviceProvider);
                 }
             }
         }

--- a/src/SmartMvvm.Xaml/SmartMvvm.Xaml.csproj
+++ b/src/SmartMvvm.Xaml/SmartMvvm.Xaml.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">


### PR DESCRIPTION
First try to create a switch/case markup extension. Unfortunately there are some issues:

1) The tests for a not setted default or null value don't pass. I expect a `DependencyProperty.UnsetValue` here, but it returns `null` both times. If I debug in the converter, it correctly returns `DependencyProperty.UnsetValue`. 

2) I want to allow the user to use a markup extension both for the key and value of the case. Currently it is only created for the key, but it doesn't work as expected both in test and view. The return value is always `null`. At the switch view, I added a "custom" color in the list box with a corresponding case inside the switch, which should evaluate the distinct custom color combobox.

Maybe you can help me with that, thanks in advance!

PS: Interestingly this PR shows the checks as "passed", but there are (above mentioned) failing tests during ci pipeline execution.