### PR TITLE
chore: Fix test execution in AppVeyor

### DIFF
--- a/.ci/build.ps1
+++ b/.ci/build.ps1
@@ -18,3 +18,8 @@ if ($versionSuffix)
 Update-AppveyorBuild -Version "$version"
 
 dotnet pack $props
+
+if ($LASTEXITCODE)
+{
+    exit $LASTEXITCODE
+}

--- a/.ci/test.ps1
+++ b/.ci/test.ps1
@@ -4,3 +4,8 @@ $project = "$PSScriptRoot\..\src\SmartMvvm.Xaml.UnitTests\SmartMvvm.Xaml.UnitTes
 $props = @($project, '-c', 'Release')
 
 dotnet test $props
+
+if ($LASTEXITCODE)
+{
+    exit $LASTEXITCODE
+}


### PR DESCRIPTION
This PR should fix the test execution behavior that failing test won't end up in failing the workflow by passing the exit code from `dotnet.exe` as PowerShell exit code.