### PR TITLE
Feature/add switch markup extension

### DIFF
--- a/src/SmartMvvm.Xaml.Sample/MainWindow.xaml
+++ b/src/SmartMvvm.Xaml.Sample/MainWindow.xaml
@@ -26,5 +26,8 @@
         <TabItem Header="Type">
             <sample:EqualTypeView />
         </TabItem>
+        <TabItem Header="Switch">
+            <sample:SwitchView />
+        </TabItem>
     </TabControl>
 </Window>

--- a/src/SmartMvvm.Xaml.Sample/SwitchView.xaml
+++ b/src/SmartMvvm.Xaml.Sample/SwitchView.xaml
@@ -1,0 +1,106 @@
+﻿<UserControl x:Class="SmartMvvm.Xaml.Sample.SwitchView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             x:Name="View"
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <DrawingBrush x:Key="NoneBrush"
+                      Stretch="None"
+                      TileMode="Tile"
+                      Viewport="0,0,8,8"
+                      ViewportUnits="Absolute">
+            <DrawingBrush.Drawing>
+                <GeometryDrawing Brush="Gray">
+                    <GeometryDrawing.Geometry>
+                        <GeometryGroup>
+                            <RectangleGeometry Rect="0,0,4,4" />
+                            <RectangleGeometry Rect="4,4,4,4" />
+                        </GeometryGroup>
+                    </GeometryDrawing.Geometry>
+                </GeometryDrawing>
+            </DrawingBrush.Drawing>
+        </DrawingBrush>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Margin="0,5"
+                    Orientation="Horizontal">
+            <TextBlock Margin="0,0,5,0"
+                       VerticalAlignment="Center"
+                       Text="Selected color:" />
+            <Border Width="20"
+                    Height="20"
+                    HorizontalAlignment="Left"
+                    BorderBrush="Black"
+                    BorderThickness="0.5">
+                <Rectangle Fill="{Switch {Binding ElementName=ListBox, Path=SelectedIndex},
+                                         {Case {Int 0},
+                                               {x:Static Brushes.Blue}},
+                                         {Case {Int 1},
+                                               {x:Static Brushes.Green}},
+                                         {Case {Int 2},
+                                               {x:Static Brushes.Red}},
+                                         {Case {Int 3},
+                                               {x:Static Brushes.Orange}},
+                                         {Case {Int 4},
+                                               {x:Static Brushes.Yellow}},
+                                         {Case {Int 5},
+                                               {Binding ElementName=CustomColorPicker, Path=SelectedItem}},
+                                         Default={StaticResource NoneBrush}}" />
+            </Border>
+        </StackPanel>
+
+        <ListBox x:Name="ListBox"
+                 Grid.Row="1">
+            <ListBoxItem Content="Blue" />
+            <ListBoxItem Content="Green" />
+            <ListBoxItem Content="Red" />
+            <ListBoxItem Content="Orange" />
+            <ListBoxItem Content="Yellow" />
+            <ListBoxItem>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="Custom:" />
+                    <ComboBox x:Name="CustomColorPicker"
+                              Margin="5,0,0,0"
+                              IsEnabled="{Equal {Binding ElementName=ListBox, Path=SelectedIndex},
+                                                {Int 5}}"
+                              SelectedIndex="0">
+                        <ComboBox.Items>
+                            <SolidColorBrush Color="RosyBrown" />
+                            <SolidColorBrush Color="LightBlue" />
+                            <SolidColorBrush Color="Fuchsia" />
+                            <SolidColorBrush Color="Lime" />
+                            <SolidColorBrush Color="Tomato" />
+                        </ComboBox.Items>
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal">
+                                    <Rectangle Width="32"
+                                               Height="8"
+                                               Margin="2"
+                                               Fill="{Binding}" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                </StackPanel>
+            </ListBoxItem>
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="ListBoxItem">
+                    <Setter Property="Padding" Value="3,4" />
+                </Style>
+            </ListBox.ItemContainerStyle>
+        </ListBox>
+
+    </Grid>
+</UserControl>

--- a/src/SmartMvvm.Xaml.Sample/SwitchView.xaml.cs
+++ b/src/SmartMvvm.Xaml.Sample/SwitchView.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace SmartMvvm.Xaml.Sample
+{
+    public partial class SwitchView
+    {
+        public SwitchView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/SmartMvvm.Xaml.UnitTests/Markup/SwitchTest.cs
+++ b/src/SmartMvvm.Xaml.UnitTests/Markup/SwitchTest.cs
@@ -1,0 +1,292 @@
+using SmartMvvm.Xaml.Markup;
+using SmartMvvm.Xaml.UnitTests.Markup.Logic;
+using System.Windows.Data;
+using Xunit;
+
+namespace SmartMvvm.Xaml.UnitTests.Markup
+{
+    public class SwitchTest
+    {
+        private const int DefaultValue = 0;
+        private readonly Case _firstCase = new Case(1, 10);
+        private readonly Case _secondCase = new Case(2, 20);
+        private readonly Case _thirdCase = new Case(3, 30);
+        private readonly Case _fourthCase = new Case(4, 40);
+        private readonly Case _fifthCase = new Case(5, 50);
+        private readonly Case _sixthCase = new Case(6, 60);
+        private readonly Case _seventhCase = new Case(7, 70);
+        private readonly Case _eightCase = new Case(8, 80);
+        private readonly Case _nullCase = new Case(null, -10);
+
+        [Fact]
+        public void Resolve_Value_NoDefaultDefined()
+        {
+            // given
+            var sut = new Switch(new Binding { Source = 100 });
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Resolve_Value_NoNullDefined()
+        {
+            // given
+            var sut = new Switch(new Binding { Source = null });
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData(1, 10)] // first case
+        [InlineData(null, -10)] // null case
+        [InlineData(10, 0)] // default
+        public void Resolve_Value_OneCase(object input, object expected)
+        {
+            // given
+            var sut = new Switch(new Binding { Source = input }, _firstCase, _nullCase) { Default = DefaultValue };
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(1, 10)] // first case
+        [InlineData(2, 20)] // second case
+        [InlineData(null, -10)] // null case
+        [InlineData(10, 0)] // default
+        public void Resolve_Value_TwoCases(object input, object expected)
+        {
+            // given
+            var sut = new Switch(new Binding { Source = input }, _firstCase, _secondCase, _nullCase) { Default = DefaultValue };
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(1, 10)] // first case
+        [InlineData(2, 20)] // second case
+        [InlineData(3, 30)] // third case
+        [InlineData(null, -10)] // null case
+        [InlineData(10, 0)] // default
+        public void Resolve_Value_ThreeCases(object input, object expected)
+        {
+            // given
+            var sut = new Switch(new Binding { Source = input }, _firstCase, _secondCase, _thirdCase, _nullCase) { Default = DefaultValue };
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(1, 10)] // first case
+        [InlineData(2, 20)] // second case
+        [InlineData(3, 30)] // third case
+        [InlineData(4, 40)] // fourth case
+        [InlineData(null, -10)] // null case
+        [InlineData(10, 0)] // default
+        public void Resolve_Value_FourthCases(object input, object expected)
+        {
+            // given
+            var sut = new Switch(new Binding { Source = input }, _firstCase, _secondCase, _thirdCase, _fourthCase, _nullCase) { Default = DefaultValue };
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(1, 10)] // first case
+        [InlineData(2, 20)] // second case
+        [InlineData(3, 30)] // third case
+        [InlineData(4, 40)] // fourth case
+        [InlineData(5, 50)] // fifth case
+        [InlineData(null, -10)] // null case
+        [InlineData(10, 0)] // default
+        public void Resolve_Value_FifthCases(object input, object expected)
+        {
+            // given
+            var sut = new Switch(new Binding { Source = input }, _firstCase, _secondCase, _thirdCase, _fourthCase, _fifthCase, _nullCase) { Default = DefaultValue };
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(1, 10)] // first case
+        [InlineData(2, 20)] // second case
+        [InlineData(3, 30)] // third case
+        [InlineData(4, 40)] // fourth case
+        [InlineData(5, 50)] // fifth case
+        [InlineData(6, 60)] // sixth case
+        [InlineData(null, -10)] // null case
+        [InlineData(10, 0)] // default
+        public void Resolve_Value_SixthCases(object input, object expected)
+        {
+            // given
+            var sut = new Switch(new Binding { Source = input }, _firstCase, _secondCase, _thirdCase, _fourthCase, _fifthCase, _sixthCase, _nullCase) { Default = DefaultValue };
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(1, 10)] // first case
+        [InlineData(2, 20)] // second case
+        [InlineData(3, 30)] // third case
+        [InlineData(4, 40)] // fourth case
+        [InlineData(5, 50)] // fifth case
+        [InlineData(6, 60)] // sixth case
+        [InlineData(7, 70)] // seventh case
+        [InlineData(null, -10)] // null case
+        [InlineData(10, 0)] // default
+        public void Resolve_Value_SeventhCases(object input, object expected)
+        {
+            // given
+            var sut = new Switch(new Binding { Source = input }, _firstCase, _secondCase, _thirdCase, _fourthCase, _fifthCase, _sixthCase, _seventhCase, _nullCase) { Default = DefaultValue };
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(1, 10)] // first case
+        [InlineData(2, 20)] // second case
+        [InlineData(3, 30)] // third case
+        [InlineData(4, 40)] // fourth case
+        [InlineData(5, 50)] // fifth case
+        [InlineData(6, 60)] // sixth case
+        [InlineData(7, 70)] // seventh case
+        [InlineData(8, 80)] // eight case
+        [InlineData(null, -10)] // null case
+        [InlineData(10, 0)] // default
+        public void Resolve_Value_EigthCases(object input, object expected)
+        {
+            // given
+            var sut = new Switch(new Binding { Source = input }, _firstCase, _secondCase, _thirdCase, _fourthCase, _fifthCase, _sixthCase, _seventhCase, _eightCase, _nullCase) { Default = DefaultValue };
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Resolve_CasesContainBindings_AllBindingsAreResolved()
+        {
+            // given
+            var conditionBinding = new Binding { Source = 11 };
+            var keyBinding = new Binding { Source = 11 };
+            var valueBinding = new Binding { Source = 22 };
+
+            var sut = new Switch(conditionBinding, new Case(keyBinding, valueBinding));
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(22, result);
+        }
+
+        [Fact]
+        public void Resolve_CasesContainChangingBindings_AllBindingsAreResolvedEachEvaluation()
+        {
+            // given
+            var conditionBinding = new Binding("[0]") { Source = new[] { 11 } };
+            var keyBinding = new Binding("[0]") { Source = new[] { 11 } };
+            var valueBinding = new Binding("[0]") { Source = new[] { 22 } };
+            var keyBinding2 = new Binding("[0]") { Source = new[] { 33 } };
+            var valueBinding2 = new Binding("[0]") { Source = new[] { 44 } };
+
+            var sut = new Switch(conditionBinding, new Case(keyBinding, valueBinding), new Case(keyBinding2, valueBinding2));
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            ((int[])conditionBinding.Source)[0] = 333;
+            ((int[])keyBinding.Source)[0] = 111;
+            ((int[])valueBinding.Source)[0] = 222;
+            ((int[])keyBinding2.Source)[0] = 333;
+            ((int[])valueBinding2.Source)[0] = 444;
+
+            var result2 = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(22, result);
+            Assert.Equal(444, result2);
+        }
+
+        [Fact]
+        public void Resolve_CaseAddedWithoutDynamicFlag_NewCaseIsIgnored()
+        {
+            // given
+            var conditionBinding = new Binding { Source = 11 };
+            var keyBinding = new Binding { Source = 33 };
+            var valueBinding = new Binding { Source = 44 };
+
+            var sut = new Switch(conditionBinding, new Case(keyBinding, valueBinding)) { Default = 99 };
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            sut.Cases.Add(new Binding { Source = 11 }, new Binding { Source = 22 });
+
+            var result2 = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(99, result);
+            Assert.Equal(99, result2);
+        }
+
+        [Fact]
+        public void Resolve_CaseAddedWithDynamicFlag_NewCaseIsRecognized()
+        {
+            // given
+            var conditionBinding = new Binding { Source = 11 };
+            var keyBinding = new Binding { Source = 33 };
+            var valueBinding = new Binding { Source = 44 };
+
+            var sut = new Switch(conditionBinding, new Case(keyBinding, valueBinding)) { Default = 99, HasDynamicCases = true };
+
+            // when
+            var result = Evaluator.Evaluate(sut);
+
+            sut.Cases.Add(new Binding { Source = 11 }, new Binding { Source = 22 });
+
+            var result2 = Evaluator.Evaluate(sut);
+
+            // then
+            Assert.Equal(99, result);
+            Assert.Equal(22, result2);
+        }
+    }
+}

--- a/src/SmartMvvm.Xaml/Markup/Case.cs
+++ b/src/SmartMvvm.Xaml/Markup/Case.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Windows.Markup;
+
+namespace SmartMvvm.Xaml.Markup
+{
+    /// <summary>
+    /// Represents a markup extension for defining a <see cref="Case"/> inside a <see cref="Switch"/>.
+    /// </summary>
+    public class Case : MarkupExtension
+    {
+        #region methods
+
+        /// <inheritdoc />
+        public override object ProvideValue(IServiceProvider serviceProvider) => this;
+
+        #endregion
+
+        #region constructors
+        
+        /// <summary>
+        /// Initializes a new instance of <see cref="Case"/>.
+        /// </summary>
+        public Case()
+        {
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of <see cref="Case"/>.
+        /// </summary>
+        /// <param name="key">The key of the <see cref="Case"/></param>
+        public Case(object key)
+        {
+            Key = key;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="Case"/>.
+        /// </summary>
+        /// <param name="key">The key of the <see cref="Case"/></param>
+        /// <param name="value">The value of the <see cref="Case"/></param>
+        public Case(object key, object value) : this(key)
+        {
+            Value = value;
+        }
+
+        #endregion
+
+        #region properties
+
+        /// <summary>
+        /// Gets or sets the key.
+        /// </summary>
+        public object Key { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value.
+        /// </summary>
+        public object Value { get; set; }
+
+        #endregion
+    }
+}

--- a/src/SmartMvvm.Xaml/Markup/Logic/LogicalBase.cs
+++ b/src/SmartMvvm.Xaml/Markup/Logic/LogicalBase.cs
@@ -14,15 +14,23 @@ namespace SmartMvvm.Xaml.Markup.Logic
     /// </summary>
     public abstract class LogicalBase : MarkupExtension
     {
-        private readonly object[] _items;
-
         /// <summary>
         /// Creates a new instance of <see cref="LogicalBase"/>.
         /// </summary>
         /// <param name="items">Contains the input values.</param>
         protected LogicalBase(params object[] items)
         {
-            _items = items;
+            Items = items;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="LogicalBase"/>.
+        /// </summary>
+        /// <param name="items">Contains the input values.</param>
+        /// <remarks>Use this constructor if the list of items can be dynamic.</remarks>
+        protected LogicalBase(IList<object> items)
+        {
+            Items = items;
         }
 
         /// <summary>
@@ -31,20 +39,25 @@ namespace SmartMvvm.Xaml.Markup.Logic
         /// <param name="index">Index of the input value.</param>
         protected object this[int index]
         {
-            get => _items[index];
-            set => _items[index] = value;
+            get => Items[index];
+            set => Items[index] = value;
         }
+
+        /// <summary>
+        /// Gets access to the underlying input values.
+        /// </summary>
+        protected IList<object> Items { get; private set; }
 
         /// <summary>
         /// Method that is invoked whenever any dependency (e.g. Binding) has changed to calculate the new resulting value.
         /// </summary>
-        /// <param name="values">Represents the evaluated values for the given <see cref="_items"/>.</param>
+        /// <param name="values">Represents the evaluated values for the given <see cref="Items"/>.</param>
         /// <returns>The result of the operation.</returns>
         protected abstract object Evaluate(IReadOnlyList<object> values);
 
         private void Dispatch(Processor processor, IServiceProvider serviceProvider)
         {
-            foreach (var item in _items)
+            foreach (var item in Items)
             {
                 switch (item)
                 {
@@ -230,7 +243,7 @@ namespace SmartMvvm.Xaml.Markup.Logic
 
                 var values = new List<object>();
 
-                for (var i = 0; i < logical._items.Length; i++)
+                for (var i = 0; i < logical.Items.Count; i++)
                     values.Insert(0, stack.Pop());
 
                 return logical.Evaluate(values);

--- a/src/SmartMvvm.Xaml/Markup/Switch.cs
+++ b/src/SmartMvvm.Xaml/Markup/Switch.cs
@@ -1,0 +1,335 @@
+﻿using SmartMvvm.Xaml.Markup.Logic;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Markup;
+
+namespace SmartMvvm.Xaml.Markup
+{
+    /// <summary>
+    /// Represents a markup extension for creating a switch expression.
+    /// </summary>
+    [ContentProperty(nameof(Cases))]
+    public sealed class Switch : LogicalBase
+    {
+        #region members
+
+        private bool _isFirstEvaluation = true;
+
+        // use a separate store for the null key, since those are not allowed in a ResourceDictionary
+        private object _nullValue = DependencyProperty.UnsetValue;
+
+        #endregion
+
+        #region constructors
+        
+        /// <summary>
+        /// Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        public Switch()
+            : base(new List<object> { null })
+        {
+        }
+
+        /// <summary>
+        ///  Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding"/></param>
+        public Switch(object binding)
+            : base(new List<object> { binding })
+        {
+        }
+
+        /// <summary>
+        ///  Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding"/></param>
+        /// <param name="first">The first <see cref="Case"/></param>
+        public Switch(object binding, Case first)
+            : base(new List<object> { binding })
+        {
+            AddCase(first);
+        }
+
+        /// <summary>
+        ///  Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding"/></param>
+        /// <param name="first">The first <see cref="Case"/></param>
+        /// <param name="second">The second <see cref="Case"/></param>
+        public Switch(object binding, Case first, Case second)
+            : base(new List<object> { binding })
+        {
+            AddCase(first);
+            AddCase(second);
+        }
+
+        /// <summary>
+        ///  Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding"/></param>
+        /// <param name="first">The first <see cref="Case"/></param>
+        /// <param name="second">The second <see cref="Case"/></param>
+        /// <param name="third">The third <see cref="Case"/></param>
+        public Switch(object binding, Case first, Case second, Case third)
+            : base(new List<object> { binding })
+        {
+            AddCase(first);
+            AddCase(second);
+            AddCase(third);
+        }
+
+        /// <summary>
+        ///  Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding"/></param>
+        /// <param name="first">The first <see cref="Case"/></param>
+        /// <param name="second">The second <see cref="Case"/></param>
+        /// <param name="third">The third <see cref="Case"/></param>
+        /// <param name="fourth">The fourth <see cref="Case"/></param>
+        public Switch(object binding, Case first, Case second, Case third, Case fourth)
+            : base(new List<object> { binding })
+        {
+            AddCase(first);
+            AddCase(second);
+            AddCase(third);
+            AddCase(fourth);
+        }
+
+        /// <summary>
+        ///  Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding"/></param>
+        /// <param name="first">The first <see cref="Case"/></param>
+        /// <param name="second">The second <see cref="Case"/></param>
+        /// <param name="third">The third <see cref="Case"/></param>
+        /// <param name="fourth">The fourth <see cref="Case"/></param>
+        /// <param name="fifth">The fifth <see cref="Case"/></param>
+        public Switch(object binding, Case first, Case second, Case third, Case fourth, Case fifth)
+            : base(new List<object> { binding })
+        {
+            AddCase(first);
+            AddCase(second);
+            AddCase(third);
+            AddCase(fourth);
+            AddCase(fifth);
+        }
+
+        /// <summary>
+        ///  Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding"/></param>
+        /// <param name="first">The first <see cref="Case"/></param>
+        /// <param name="second">The second <see cref="Case"/></param>
+        /// <param name="third">The third <see cref="Case"/></param>
+        /// <param name="fourth">The fourth <see cref="Case"/></param>
+        /// <param name="fifth">The fifth <see cref="Case"/></param>
+        /// <param name="sixth">The sixth <see cref="Case"/></param>
+        public Switch(object binding, Case first, Case second, Case third, Case fourth, Case fifth, Case sixth)
+            : base(new List<object> { binding })
+        {
+            AddCase(first);
+            AddCase(second);
+            AddCase(third);
+            AddCase(fourth);
+            AddCase(fifth);
+            AddCase(sixth);
+        }
+
+        /// <summary>
+        ///  Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding"/></param>
+        /// <param name="first">The first <see cref="Case"/></param>
+        /// <param name="second">The second <see cref="Case"/></param>
+        /// <param name="third">The third <see cref="Case"/></param>
+        /// <param name="fourth">The fourth <see cref="Case"/></param>
+        /// <param name="fifth">The fifth <see cref="Case"/></param>
+        /// <param name="sixth">The sixth <see cref="Case"/></param>
+        /// <param name="seventh">The seventh <see cref="Case"/></param>
+        public Switch(object binding, Case first, Case second, Case third, Case fourth, Case fifth, Case sixth, Case seventh)
+            : base(new List<object> { binding })
+        {
+            AddCase(first);
+            AddCase(second);
+            AddCase(third);
+            AddCase(fourth);
+            AddCase(fifth);
+            AddCase(sixth);
+            AddCase(seventh);
+        }
+
+        /// <summary>
+        ///  Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding"/></param>
+        /// <param name="first">The first <see cref="Case"/></param>
+        /// <param name="second">The second <see cref="Case"/></param>
+        /// <param name="third">The third <see cref="Case"/></param>
+        /// <param name="fourth">The fourth <see cref="Case"/></param>
+        /// <param name="fifth">The fifth <see cref="Case"/></param>
+        /// <param name="sixth">The sixth <see cref="Case"/></param>
+        /// <param name="seventh">The seventh <see cref="Case"/></param>
+        /// <param name="eighth">The eighth <see cref="Case"/></param>
+        public Switch(object binding, Case first, Case second, Case third, Case fourth, Case fifth, Case sixth, Case seventh, Case eighth)
+            : base(new List<object> { binding })
+        {
+            AddCase(first);
+            AddCase(second);
+            AddCase(third);
+            AddCase(fourth);
+            AddCase(fifth);
+            AddCase(sixth);
+            AddCase(seventh);
+            AddCase(eighth);
+        }
+
+        /// <summary>
+        ///  Initializes a new instance of <see cref="Switch"/>.
+        /// </summary>
+        /// <param name="binding">The <see cref="Binding"/></param>
+        /// <param name="first">The first <see cref="Case"/></param>
+        /// <param name="second">The second <see cref="Case"/></param>
+        /// <param name="third">The third <see cref="Case"/></param>
+        /// <param name="fourth">The fourth <see cref="Case"/></param>
+        /// <param name="fifth">The fifth <see cref="Case"/></param>
+        /// <param name="sixth">The sixth <see cref="Case"/></param>
+        /// <param name="seventh">The seventh <see cref="Case"/></param>
+        /// <param name="eighth">The eight <see cref="Case"/></param>
+        /// <param name="ninth">The ninth <see cref="Case"/></param>
+        public Switch(object binding, Case first, Case second, Case third, Case fourth, Case fifth, Case sixth, Case seventh, Case eighth, Case ninth)
+            : base(new List<object> { binding })
+        {
+            AddCase(first);
+            AddCase(second);
+            AddCase(third);
+            AddCase(fourth);
+            AddCase(fifth);
+            AddCase(sixth);
+            AddCase(seventh);
+            AddCase(eighth);
+            AddCase(ninth);
+        }
+        
+        #endregion
+
+        #region properties
+
+        /// <summary>
+        /// Gets or sets the <see cref="BindingBase" /> used a s switch value.
+        /// </summary>
+        public BindingBase Binding 
+        {
+            get => Items[0] as BindingBase;
+            set => Items[0] = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Case"/>s.
+        /// </summary>
+        public ResourceDictionary Cases { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets the default value.
+        /// </summary>
+        public object Default { get; set; } = DependencyProperty.UnsetValue;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the cases might change after each evaluation.
+        /// </summary>
+        /// <remarks>Leaving this flag disabled can lead to a better performance for subsequent evaluations.</remarks>
+        public bool HasDynamicCases { get; set; }
+
+        #endregion
+
+        #region methods
+
+        private void AddCase(Case newCase)
+        {
+            if (newCase.Key is null)
+                _nullValue = newCase.Value;
+            else
+                Cases.Add(newCase.Key, newCase.Value);
+        }
+
+        /// <inheritdoc />
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            if (HasDynamicCases && Items.Count > 1)
+            {
+                var binding = Items[0];
+
+                Items.Clear();
+                Items.Add(binding);
+            }
+
+            if ( (_isFirstEvaluation || HasDynamicCases) && HasAnyMarkupExtensionInCases())
+            {
+                foreach (DictionaryEntry entry in Cases)
+                {
+                    Items.Add(entry.Key);
+                    Items.Add(entry.Value);
+                }
+
+                Items.Add(_nullValue);
+                Items.Add(Default);
+            }
+
+            _isFirstEvaluation = false;
+
+            return base.ProvideValue(serviceProvider);
+        }
+
+        private bool HasAnyMarkupExtensionInCases()
+        {
+            if (_nullValue is MarkupExtension)
+                return true;
+
+            if (Default is MarkupExtension)
+                return true;
+
+            foreach (DictionaryEntry entry in Cases)
+            {
+                if (entry.Key is MarkupExtension)
+                    return true;
+
+                if (entry.Value is MarkupExtension)
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc />
+        protected override object Evaluate(IReadOnlyList<object> values)
+        {
+            var key = values[0];
+
+            // value count will be one if cases contained no markup extensions
+            if (values.Count == 1)
+            {
+                if (key is null)
+                    return _nullValue;
+
+                return Cases.Contains(key) ? Cases[key] : Default;
+            }
+
+            if (key is null)
+                return values[values.Count - 2];
+
+            // since keys could contain bindings we need to do a manual lookup
+            for (var i = 1; i < values.Count - 2; i += 2)
+            {
+                if (Equals(key, values[i]))
+                    return values[i + 1];
+            }
+
+            return values[values.Count - 1];
+        }
+
+        #endregion
+    }
+}

--- a/src/SmartMvvm.Xaml/SmartMvvm.Xaml.csproj
+++ b/src/SmartMvvm.Xaml/SmartMvvm.Xaml.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">


### PR DESCRIPTION
Reopened PR #3 but with a different source branch.

This PR brings a switch markup extension to easily switch between multiple bindings / resources in XAML markup in an easy way.

In contrast to C#'s switch extension this one also supports dynamic keys (markup extensions, bindings) for each case. But be aware that every markup extension might have impact on general performance, e.g. bindings heavily rely on reflection. 

In the future we might improve performance by extending caching of already evaluated data, but for now each execution reevaluates all markup extensions.