### PR TITLE
feat: Simplify Avalonia

### DIFF
--- a/src/SmartMvvm.Avalonia.Xaml.Sample/CalculatorView.axaml
+++ b/src/SmartMvvm.Avalonia.Xaml.Sample/CalculatorView.axaml
@@ -52,8 +52,8 @@
                                  {Calc {Binding ElementName=NumberBoxX, Path=Text},
                                        {Binding ElementName=NumberBoxY, Path=Text},
                                        {Binding ElementName=NumberBoxZ, Path=Text},
-                                       ExpressionBind={Binding ElementName=ExpressionBox,
-                                                               Path=Text},
+                                       Expression={Binding ElementName=ExpressionBox,
+                                                           Path=Text},
                                        FallbackValue='Invalid expression'}}" />
     </StackPanel>
 </UserControl>

--- a/src/SmartMvvm.Avalonia.Xaml.Sample/GeneralView.axaml
+++ b/src/SmartMvvm.Avalonia.Xaml.Sample/GeneralView.axaml
@@ -44,7 +44,15 @@
                              Else={If {Less {Use Width},
                                             {Use Height}},
                                       Then='Width is less than Height',
-                                      Else='Width is greater than Height'}}" />
+                                      Else='Width is greater than Height'}}"
+                   Foreground="{If {Equal {Use Width},
+                                          {Use Height},
+                                          Epsilon=10},
+                                   Then={x:Static Brushes.Black},
+                                   Else={If {Less {Use Width},
+                                                  {Use Height}},
+                                            Then={x:Static Brushes.Green},
+                                            Else={x:Static Brushes.Blue}}}" />
         <TextBlock Text="{Format Altogether: {0} pixels.,
                                  {Calc 'x * y',
                                        {Use Width},

--- a/src/SmartMvvm.Avalonia.Xaml.UnitTests/Markup/Logic/CalcTest.cs
+++ b/src/SmartMvvm.Avalonia.Xaml.UnitTests/Markup/Logic/CalcTest.cs
@@ -84,9 +84,9 @@ namespace SmartMvvm.Avalonia.Xaml.UnitTests.Markup.Logic
             // given
             var sut = new Calc(string.Empty)
             {
-                ExpressionBind = new Binding { Source = expression },
-                MinBind = new Binding { Source = min },
-                MaxBind = new Binding { Source = max }
+                Expression = new Binding { Source = expression },
+                Min = new Binding { Source = min },
+                Max = new Binding { Source = max }
             };
 
             // when

--- a/src/SmartMvvm.Avalonia.Xaml.UnitTests/Markup/Logic/FormatTest.cs
+++ b/src/SmartMvvm.Avalonia.Xaml.UnitTests/Markup/Logic/FormatTest.cs
@@ -30,7 +30,7 @@ namespace SmartMvvm.Avalonia.Xaml.UnitTests.Markup.Logic
             var sut = new Format(first)
             {
                 Culture = CultureInfo.InvariantCulture,
-                FormatBind = new Binding { Source = format }
+                FormatString = new Binding { Source = format }
             };
 
             // when

--- a/src/SmartMvvm.Avalonia.Xaml.UnitTests/Markup/Logic/IfTest.cs
+++ b/src/SmartMvvm.Avalonia.Xaml.UnitTests/Markup/Logic/IfTest.cs
@@ -65,7 +65,7 @@ namespace SmartMvvm.Avalonia.Xaml.UnitTests.Markup.Logic
         public void True_Condition_Returns_ThenBinding()
         {
             // given
-            var sut = new If(true) { ThenBind = new Binding { Source = "RESULT" } };
+            var sut = new If(true) { Then = new Binding { Source = "RESULT" } };
 
             // when
             var result = Evaluator.Evaluate(sut);
@@ -78,7 +78,7 @@ namespace SmartMvvm.Avalonia.Xaml.UnitTests.Markup.Logic
         public void False_Condition_Retuns_ElseBinding()
         {
             // given
-            var sut = new If(false) { ElseBind = new Binding { Source = "RESULT" } };
+            var sut = new If(false) { Else = new Binding { Source = "RESULT" } };
 
             // when
             var result = Evaluator.Evaluate(sut);

--- a/src/SmartMvvm.Avalonia.Xaml.UnitTests/Markup/Logic/ThicknessTest.cs
+++ b/src/SmartMvvm.Avalonia.Xaml.UnitTests/Markup/Logic/ThicknessTest.cs
@@ -105,10 +105,10 @@ namespace SmartMvvm.Avalonia.Xaml.UnitTests.Markup.Logic
             // given
             var sut = new Thickness
             {
-                LeftBind = new Binding { Source = left },
-                TopBind = new Binding { Source = top },
-                RightBind = new Binding { Source = right },
-                BottomBind = new Binding { Source = bottom },
+                Left = new Binding { Source = left },
+                Top = new Binding { Source = top },
+                Right = new Binding { Source = right },
+                Bottom = new Binding { Source = bottom },
             };
 
             // when

--- a/src/SmartMvvm.Avalonia.Xaml/Markup/Logic/Calc.cs
+++ b/src/SmartMvvm.Avalonia.Xaml/Markup/Logic/Calc.cs
@@ -21,6 +21,13 @@ public class Calc : LogicalBase
     /// <summary>
     /// Initializes a new in instance of <see cref="Calc"/>.
     /// </summary>
+    public Calc()
+        : base(null, null, null)
+    { }
+
+    /// <summary>
+    /// Initializes a new in instance of <see cref="Calc"/>.
+    /// </summary>
     /// <param name="expression">Mathematical expression to evaluate.</param>
     public Calc(string expression)
         : base(expression, null, null)
@@ -109,9 +116,9 @@ public class Calc : LogicalBase
     /// <summary>
     /// Gets or sets the mathematical expression used for evaluation.
     /// </summary>
-    public string Expression
+    public object Expression
     {
-        get => this[0] as string;
+        get => this[0];
         set => this[0] = value;
     }
 
@@ -130,33 +137,6 @@ public class Calc : LogicalBase
     public object Max
     {
         get => this[2];
-        set => this[2] = value;
-    }
-
-    /// <summary>
-    /// Gets or sets the binding that points to the mathematical expression used for evaluation.
-    /// </summary>
-    public IBinding ExpressionBind
-    {
-        get => this[0] as IBinding;
-        set => this[0] = value;
-    }
-
-    /// <summary>
-    /// Gets or sets the binding that points to a value that used to define the lower limit for the result.
-    /// </summary>
-    public IBinding MinBind
-    {
-        get => this[1] as IBinding;
-        set => this[1] = value;
-    }
-
-    /// <summary>
-    /// Gets or sets the binding that points to a value that used to define the upper limit for the result.
-    /// </summary>
-    public IBinding MaxBind
-    {
-        get => this[2] as IBinding;
         set => this[2] = value;
     }
 

--- a/src/SmartMvvm.Avalonia.Xaml/Markup/Logic/Format.cs
+++ b/src/SmartMvvm.Avalonia.Xaml/Markup/Logic/Format.cs
@@ -93,18 +93,9 @@ public class Format : LogicalBase
     /// <summary>
     /// Gets or sets the format string that is used for formatting the input values.
     /// </summary>
-    public string FormatString
+    public object FormatString
     {
-        get => this[0] as string;
-        set => this[0] = value;
-    }
-
-    /// <summary>
-    /// Gets or sets a binding that points to the format string that is used for formatting the input values.
-    /// </summary>
-    public IBinding FormatBind
-    {
-        get => this[0] as IBinding;
+        get => this[0];
         set => this[0] = value;
     }
 

--- a/src/SmartMvvm.Avalonia.Xaml/Markup/Logic/If.cs
+++ b/src/SmartMvvm.Avalonia.Xaml/Markup/Logic/If.cs
@@ -37,29 +37,11 @@ public class If : LogicalBase
     }
 
     /// <summary>
-    /// Gets or sets a binding that points to a value that is returned if the given condition evaluates to <c>true</c>.
-    /// </summary>
-    public IBinding ThenBind
-    {
-        get => this[1] as IBinding;
-        set => this[1] = value;
-    }
-
-    /// <summary>
     /// Gets or sets a value that is returned if the given condition evaluates to <c>false</c>.
     /// </summary>
     public object Else
     {
         get => this[2];
-        set => this[2] = value;
-    }
-
-    /// <summary>
-    /// Gets or sets a binding that points to a value that is returned if the given condition evaluates to <c>false</c>.
-    /// </summary>
-    public IBinding ElseBind
-    {
-        get => this[2] as IBinding;
         set => this[2] = value;
     }
 

--- a/src/SmartMvvm.Avalonia.Xaml/Markup/Logic/Switch.cs
+++ b/src/SmartMvvm.Avalonia.Xaml/Markup/Logic/Switch.cs
@@ -219,9 +219,9 @@ public sealed class Switch : LogicalBase
     /// <summary>
     /// Gets or sets the <see cref="IBinding" /> used a s switch value.
     /// </summary>
-    public IBinding Binding
+    public object Binding
     {
-        get => Items[0] as IBinding;
+        get => Items[0];
         set => Items[0] = value;
     }
 

--- a/src/SmartMvvm.Avalonia.Xaml/Markup/Logic/Thickness.cs
+++ b/src/SmartMvvm.Avalonia.Xaml/Markup/Logic/Thickness.cs
@@ -54,29 +54,11 @@ public class Thickness : LogicalBase
     }
 
     /// <summary>
-    /// Gets or sets a binding that points to the value that is used for the width of the left side of the bounding rectangle.
-    /// </summary>
-    public IBinding LeftBind
-    {
-        get => this[0] as IBinding;
-        set => this[0] = value;
-    }
-
-    /// <summary>
     /// Gets or sets the width of the upper side of the bounding rectangle.
     /// </summary>
     public object Top
     {
         get => this[1];
-        set => this[1] = value;
-    }
-
-    /// <summary>
-    /// Gets or sets a binding that points to the value that is used for the width of the upper side of the bounding rectangle.
-    /// </summary>
-    public IBinding TopBind
-    {
-        get => this[1] as IBinding;
         set => this[1] = value;
     }
 
@@ -90,29 +72,11 @@ public class Thickness : LogicalBase
     }
 
     /// <summary>
-    /// Gets or sets a binding that points to the value that is used for the width of the right side of the bounding rectangle.
-    /// </summary>
-    public IBinding RightBind
-    {
-        get => this[2] as IBinding;
-        set => this[2] = value;
-    }
-
-    /// <summary>
     /// Gets or sets the width of the lower side of the bounding rectangle.
     /// </summary>
     public object Bottom
     {
         get => this[3];
-        set => this[3] = value;
-    }
-
-    /// <summary>
-    /// Gets or sets a binding that points to the value that is used for the width of the lower side of the bounding rectangle.
-    /// </summary>
-    public IBinding BottomBind
-    {
-        get => this[3] as IBinding;
         set => this[3] = value;
     }
 


### PR DESCRIPTION
- no need for *Bind properties since Avalonia won't emit a parsing error when assigning a Binding to a property of type object unlike WPF